### PR TITLE
Use existing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## 依存関係
 
 - asyncrun.vim(https://github.com/skywind3000/asyncrun.vim)
-- mplayer(Linux) or afplay(Mac)
+- mplayer or afplay
 - magicalstick(https://github.com/himanoa/magicalstick)
 - coreutils(Mac)( `brew install coreutils` )
 

--- a/plugin/ttene.vim
+++ b/plugin/ttene.vim
@@ -5,13 +5,20 @@ endif
 
 let g:loaded_ttenesana = 1
 
-if has('unix')
+if executable('mplayer')
   let g:play_command = 'mplayer'
-  let g:shuf = 'shuf'
-endif
-if has('mac')
+elseif executable('afplay')
   let g:play_command = 'afplay'
+else
+  finish
+endif
+
+if executable('shuf')
+  let g:shuf = 'shuf'
+elseif executable('gshuf')
   let g:shuf = 'gshuf'
+else
+  finish
 endif
 
 let g:voices = expand('<sfile>:p:h') . '/../voices'


### PR DESCRIPTION
In any OS X environment, afplay is not installable, but mplayer is installable.
So modified to use existing command, instead of OS-switching.