### PR TITLE
リファクタリング、外部コマンドの処理を Vim script で実装、#4 の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 - asyncrun.vim(https://github.com/skywind3000/asyncrun.vim)
 - mplayer or afplay
 - magicalstick(https://github.com/himanoa/magicalstick)
-- coreutils(Mac)( `brew install coreutils` )
 
 ## インストール(dein)
 

--- a/plugin/ttene.vim
+++ b/plugin/ttene.vim
@@ -43,6 +43,8 @@ function! s:pick_voice() abort
   if empty(voices)
     return ''
   endif
+  " 0 から len(voices) - 1 までの疑似乱数 (整数) を生成する
+  " http://vim-jp.org/vim-users-jp/2009/11/05/Hack-98.html
   let match_end = matchend(reltimestr(reltime()), '\d\+\.') + 1
   let i = reltimestr(reltime())[l:match_end : ] % len(voices)
   return voices[i]

--- a/plugin/ttene.vim
+++ b/plugin/ttene.vim
@@ -6,21 +6,21 @@ endif
 let g:loaded_ttenesana = 1
 
 if executable('mplayer')
-  let g:play_command = 'mplayer'
+  let g:ttene_play_command = 'mplayer'
 elseif executable('afplay')
-  let g:play_command = 'afplay'
+  let g:ttene_play_command = 'afplay'
 else
   finish
 endif
 
 if executable('shuf')
-  let g:shuf = 'shuf'
+  let g:ttene_shuf = 'shuf'
 elseif executable('gshuf')
-  let g:shuf = 'gshuf'
+  let g:ttene_shuf = 'gshuf'
 else
   finish
 endif
 
 let g:voices = expand('<sfile>:p:h') . '/../voices'
-let g:on_enter = ":AsyncRun find " . g:voices . " | " . g:shuf . "| head -n1 | xargs -In1 " . g:play_command . " n1"
+let g:on_enter = ":AsyncRun find " . g:voices . " | " . g:ttene_shuf . "| head -n1 | xargs -In1 " . g:ttene_play_command . " n1"
 autocmd InsertEnter * imap <script> <CR> <ESC>:<C-u>execute g:on_enter<CR>a<CR>

--- a/plugin/ttene.vim
+++ b/plugin/ttene.vim
@@ -5,20 +5,24 @@ endif
 
 let g:loaded_ttene = 1
 
-if executable('mplayer')
-  let g:ttene_play_command = 'mplayer'
-elseif executable('afplay')
-  let g:ttene_play_command = 'afplay'
-else
-  finish
+if !exists('g:ttene_play_command') || !executable(g:ttene_play_command)
+  if executable('mplayer')
+    let g:ttene_play_command = 'mplayer'
+  elseif executable('afplay')
+    let g:ttene_play_command = 'afplay'
+  else
+    finish
+  endif
 endif
 
-if executable('shuf')
-  let g:ttene_shuf = 'shuf'
-elseif executable('gshuf')
-  let g:ttene_shuf = 'gshuf'
-else
-  finish
+if !exists('g:ttene_shuf') || !executable(g:ttene_shuf)
+  if executable('shuf')
+    let g:ttene_shuf = 'shuf'
+  elseif executable('gshuf')
+    let g:ttene_shuf = 'gshuf'
+  else
+    finish
+  endif
 endif
 
 let s:voices = expand('<sfile>:p:h') . '/../voices'

--- a/plugin/ttene.vim
+++ b/plugin/ttene.vim
@@ -33,6 +33,10 @@ endfunction
 
 function! s:prepare_mappings() abort
   inoremap <buffer> <CR> <C-o>:<C-u>call <SID>play()<CR><CR>
+  augroup ttene-local
+    autocmd!
+    autocmd InsertLeave <buffer> call s:play()
+  augroup END
 endfunction
 
 augroup ttene

--- a/plugin/ttene.vim
+++ b/plugin/ttene.vim
@@ -28,4 +28,8 @@ function! s:on_enter() abort
   execute "normal! \<CR>"
 endfunction
 
-autocmd InsertEnter * inoremap <CR> <ESC>:<C-u>call <SID>on_enter()<CR>
+function! s:prepare_mappings() abort
+  inoremap <buffer> <CR> <ESC>:<C-u>call <SID>on_enter()<CR>
+endfunction
+
+autocmd InsertEnter * call s:prepare_mappings()

--- a/plugin/ttene.vim
+++ b/plugin/ttene.vim
@@ -27,12 +27,12 @@ endif
 
 let s:voices = expand('<sfile>:p:h') . '/../voices'
 
-function! s:on_enter() abort
+function! s:play() abort
   execute 'AsyncRun find ' . s:voices . ' | ' . g:ttene_shuf . '| head -n1 | xargs -In1 ' . g:ttene_play_command . ' n1'
 endfunction
 
 function! s:prepare_mappings() abort
-  inoremap <buffer> <CR> <C-o>:<C-u>call <SID>on_enter()<CR><CR>
+  inoremap <buffer> <CR> <C-o>:<C-u>call <SID>play()<CR><CR>
 endfunction
 
 augroup ttene

--- a/plugin/ttene.vim
+++ b/plugin/ttene.vim
@@ -21,6 +21,11 @@ else
   finish
 endif
 
-let g:voices = expand('<sfile>:p:h') . '/../voices'
-let g:on_enter = ":AsyncRun find " . g:voices . " | " . g:ttene_shuf . "| head -n1 | xargs -In1 " . g:ttene_play_command . " n1"
-autocmd InsertEnter * imap <script> <CR> <ESC>:<C-u>execute g:on_enter<CR>a<CR>
+let s:voices = expand('<sfile>:p:h') . '/../voices'
+
+function! s:on_enter() abort
+  execute 'AsyncRun find ' . s:voices . ' | ' . g:ttene_shuf . '| head -n1 | xargs -In1 ' . g:ttene_play_command . ' n1'
+  execute "normal! \<CR>"
+endfunction
+
+autocmd InsertEnter * inoremap <CR> <ESC>:<C-u>call <SID>on_enter()<CR>

--- a/plugin/ttene.vim
+++ b/plugin/ttene.vim
@@ -29,11 +29,10 @@ let s:voices = expand('<sfile>:p:h') . '/../voices'
 
 function! s:on_enter() abort
   execute 'AsyncRun find ' . s:voices . ' | ' . g:ttene_shuf . '| head -n1 | xargs -In1 ' . g:ttene_play_command . ' n1'
-  execute "normal! \<CR>"
 endfunction
 
 function! s:prepare_mappings() abort
-  inoremap <buffer> <CR> <ESC>:<C-u>call <SID>on_enter()<CR>
+  inoremap <buffer> <CR> <C-o>:<C-u>call <SID>on_enter()<CR><CR>
 endfunction
 
 augroup ttene

--- a/plugin/ttene.vim
+++ b/plugin/ttene.vim
@@ -1,9 +1,9 @@
 scriptencoding utf-8
-if exists('g:loaded_ttenesana')
+if exists('g:loaded_ttene')
   finish
 endif
 
-let g:loaded_ttenesana = 1
+let g:loaded_ttene = 1
 
 if executable('mplayer')
   let g:ttene_play_command = 'mplayer'

--- a/plugin/ttene.vim
+++ b/plugin/ttene.vim
@@ -32,4 +32,7 @@ function! s:prepare_mappings() abort
   inoremap <buffer> <CR> <ESC>:<C-u>call <SID>on_enter()<CR>
 endfunction
 
-autocmd InsertEnter * call s:prepare_mappings()
+augroup ttene
+  autocmd!
+  autocmd InsertEnter * call s:prepare_mappings()
+augroup END


### PR DESCRIPTION
ごった煮 PR 送ってすいません…
その上当方 Windows (WSL) 環境なので mplayer で実際に再生できるか確認してなくて壊してたらごめんなさい…

* 機能
  * プレーヤーのコマンドを変数で指定可能にした
    * `let g:ttene_play_command = 'プレーヤーのコマンド'`
  * ノーマルモード対応 (#4)

* 修正
  * グローバル変数はなるべく使わないよう修正
  * `autocmd` は `augroup` でグループ名を指定して実行するよう修正
  * Vim script で処理を実装して coreutils 不要にした
